### PR TITLE
ランキング表示フォーマットの改善

### DIFF
--- a/add_new_data.py
+++ b/add_new_data.py
@@ -53,7 +53,7 @@ def get_ranking_data():
 def get_video_html(rank, title, vid, viewcount):
     return f"""
       <b>{rank} 位 {viewcount:,} 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/{vid}" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/{vid}" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/{vid}">{title}</a></iframe><br />"""
 
 

--- a/add_new_data.py
+++ b/add_new_data.py
@@ -52,7 +52,7 @@ def get_ranking_data():
 
 def get_video_html(rank, title, vid, viewcount):
     return f"""
-      {rank} 位 {viewcount:,} 再生<br />
+      <b>{rank} 位 {viewcount:,} 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/{vid}" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/{vid}">{title}</a></iframe><br />"""
 

--- a/data/20240525.html
+++ b/data/20240525.html
@@ -15,304 +15,304 @@
       <li><a href="../index.html">他の日のランキング</a></li>
     </ui>
     <p>
-      1 位 30,598,274 再生<br />
+      <b>1 位 30,598,274 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm8628149" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm8628149">【東方】Bad Apple!!　ＰＶ【影絵】</a></iframe><br />
-      2 位 22,724,730 再生<br />
+      <b>2 位 22,724,730 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2057168" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2057168">M.C.ドナルドはダンスに夢中なのか？最終鬼畜道化師ドナルド・Ｍ</a></iframe><br />
-      3 位 21,956,120 再生<br />
+      <b>3 位 21,956,120 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm9" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm9">新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師</a></iframe><br />
-      4 位 20,589,057 再生<br />
+      <b>4 位 20,589,057 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm35919998" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm35919998">【おにべろす】出会いから今までまとめ 百鬼あやめ(鬼)と戌亥とこ（ベロス）</a></iframe><br />
-      5 位 17,547,000 再生<br />
+      <b>5 位 17,547,000 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm22954889" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm22954889">幕末志士達のスマブラ６４実況プレイ</a></iframe><br />
-      6 位 17,497,458 再生<br />
+      <b>6 位 17,497,458 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm15630734" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm15630734">『初音ミク』千本桜『オリジナル曲PV』</a></iframe><br />
-      7 位 17,297,205 再生<br />
+      <b>7 位 17,297,205 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm25932228" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm25932228">【ウォルピス社】アスノヨゾラ哨戒班を歌ってみました【提供】</a></iframe><br />
-      8 位 16,901,235 再生<br />
+      <b>8 位 16,901,235 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1097445" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1097445">【初音ミク】みくみくにしてあげる♪【してやんよ】</a></iframe><br />
-      9 位 16,276,932 再生<br />
+      <b>9 位 16,276,932 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1715919" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1715919">初音ミク　が　オリジナル曲を歌ってくれたよ「メルト」</a></iframe><br />
-      10 位 15,903,319 再生<br />
+      <b>10 位 15,903,319 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm10780722" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm10780722">おちゃめ機能　歌った</a></iframe><br />
-      11 位 15,687,195 再生<br />
+      <b>11 位 15,687,195 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm20886696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm20886696">ブリキノダンス　うたった【SymaG】</a></iframe><br />
-      12 位 15,116,840 再生<br />
+      <b>12 位 15,116,840 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm10759623" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm10759623">初音ミク・巡音ルカ　オリジナル曲　「ワールズエンド・ダンスホール」</a></iframe><br />
-      13 位 14,871,347 再生<br />
+      <b>13 位 14,871,347 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/so30413239" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/so30413239">けものフレンズ　1話「さばんなちほー」</a></iframe><br />
-      14 位 14,717,789 再生<br />
+      <b>14 位 14,717,789 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11809611" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11809611">【オリジナル曲PV】マトリョシカ【初音ミク・GUMI】</a></iframe><br />
-      15 位 12,824,335 再生<br />
+      <b>15 位 12,824,335 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29885262" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29885262">シャルル　歌ってみたのはメガテラ・ゼロ</a></iframe><br />
-      16 位 12,731,279 再生<br />
+      <b>16 位 12,731,279 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11398357" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11398357">DECO*27 - モザイクロール feat. GUMI</a></iframe><br />
-      17 位 12,516,504 再生<br />
+      <b>17 位 12,516,504 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31791630" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31791630">wowaka『アンノウン・マザーグース』feat. 初音ミク</a></iframe><br />
-      18 位 12,412,768 再生<br />
+      <b>18 位 12,412,768 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm23225630" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm23225630">米津玄師 MV「アイネクライネ」</a></iframe><br />
-      19 位 12,244,684 再生<br />
+      <b>19 位 12,244,684 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm9714351" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm9714351">初音ミク　オリジナル曲　「ローリンガール」</a></iframe><br />
-      20 位 12,130,390 再生<br />
+      <b>20 位 12,130,390 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm24276234" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm24276234">【IA】アスノヨゾラ哨戒班【オリジナル】</a></iframe><br />
-      21 位 12,069,050 再生<br />
+      <b>21 位 12,069,050 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm500873" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm500873">組曲『ニコニコ動画』 </a></iframe><br />
-      22 位 12,052,862 再生<br />
+      <b>22 位 12,052,862 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32103696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32103696">ドラマツルギー 歌ってみた【りぶ】</a></iframe><br />
-      23 位 12,044,281 再生<br />
+      <b>23 位 12,044,281 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm35979548" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm35979548">YOASOBI「夜に駆ける」 Official Music Video</a></iframe><br />
-      24 位 11,917,594 再生<br />
+      <b>24 位 11,917,594 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27965309" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27965309">DECO*27 - ゴーストルール feat. 初音ミク</a></iframe><br />
-      25 位 11,830,687 再生<br />
+      <b>25 位 11,830,687 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6188097" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6188097">【マリオ64実況】　奴が来る　伍【幕末志士】</a></iframe><br />
-      26 位 11,800,456 再生<br />
+      <b>26 位 11,800,456 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm15971140" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm15971140">エンヴィキャットウォーク 歌ってみた【りぶ】</a></iframe><br />
-      27 位 11,748,254 再生<br />
+      <b>27 位 11,748,254 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/so23335421" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/so23335421">ご注文はうさぎですか？　第1羽「ひと目で、尋常でないもふもふだと見抜いたよ」</a></iframe><br />
-      28 位 11,500,649 再生<br />
+      <b>28 位 11,500,649 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31606995" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31606995">ハチ MV「砂の惑星 feat.初音ミク」</a></iframe><br />
-      29 位 11,484,143 再生<br />
+      <b>29 位 11,484,143 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm9354085" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm9354085">自演乙</a></iframe><br />
-      30 位 11,458,541 再生<br />
+      <b>30 位 11,458,541 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm17520775" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm17520775">【IA】六兆年と一夜物語【オリジナル曲・PV付】</a></iframe><br />
-      31 位 11,413,492 再生<br />
+      <b>31 位 11,413,492 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2049295" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2049295">【 Silver Forest × U.N.オーエンは彼女なのか？ 】 −sweet little sister−</a></iframe><br />
-      32 位 11,228,694 再生<br />
+      <b>32 位 11,228,694 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29854242" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29854242">シャルル／バルーン</a></iframe><br />
-      33 位 11,152,069 再生<br />
+      <b>33 位 11,152,069 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2937784" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2937784">初音ミクオリジナル曲　「初音ミクの消失（LONG VERSION）」</a></iframe><br />
-      34 位 10,942,373 再生<br />
+      <b>34 位 10,942,373 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm14583646" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm14583646">天ノ弱／164 feat.GUMI</a></iframe><br />
-      35 位 10,824,481 再生<br />
+      <b>35 位 10,824,481 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm23328696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm23328696">【ニコニコラボ】Blessing【SINGERS ver.A】</a></iframe><br />
-      36 位 10,724,808 再生<br />
+      <b>36 位 10,724,808 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm22138447" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm22138447">GUMI MV「ドーナツホール」</a></iframe><br />
-      37 位 10,702,232 再生<br />
+      <b>37 位 10,702,232 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm26515642" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm26515642">【血界戦線ED】シュガーソングとビターステップを歌ってみた　まるぐり</a></iframe><br />
-      38 位 10,693,186 再生<br />
+      <b>38 位 10,693,186 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm22960446" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm22960446">【初音ミク】 ウミユリ海底譚 【オリジナル曲】</a></iframe><br />
-      39 位 10,633,598 再生<br />
+      <b>39 位 10,633,598 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm19133907" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm19133907">【初音ミク＆GUMI】脳漿炸裂ガール【オリジナル】</a></iframe><br />
-      40 位 10,623,571 再生<br />
+      <b>40 位 10,623,571 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm30171731" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm30171731">【FantasticYouth】 DAYBREAK FRONTLINE 歌ってみた 【LowFat×おん湯(♨︎)】</a></iframe><br />
-      41 位 10,542,768 再生<br />
+      <b>41 位 10,542,768 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm3504435" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm3504435">初音ミク　が　オリジナル曲を歌ってくれたよ「ワールドイズマイン」</a></iframe><br />
-      42 位 10,446,801 再生<br />
+      <b>42 位 10,446,801 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm8082467" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm8082467">初音ミク　オリジナル曲　「裏表ラバーズ」</a></iframe><br />
-      43 位 10,270,471 再生<br />
+      <b>43 位 10,270,471 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6666016" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6666016">「ロミオとシンデレラ」　オリジナル曲　vo.初音ミク</a></iframe><br />
-      44 位 10,220,385 再生<br />
+      <b>44 位 10,220,385 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm8089993" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm8089993">【鏡音リン】炉心融解【オリジナル】</a></iframe><br />
-      45 位 10,217,861 再生<br />
+      <b>45 位 10,217,861 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11729204" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11729204">【うるおぼえで歌ってみた】only my railgun【ぐるたみん】</a></iframe><br />
-      46 位 10,188,109 再生<br />
+      <b>46 位 10,188,109 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32798041" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32798041">ロキ／鏡音リン・みきとP</a></iframe><br />
-      47 位 10,065,837 再生<br />
+      <b>47 位 10,065,837 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27831783" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27831783">【ウォルピス社】時ノ雨、最終戦争を歌ってみました【提供】</a></iframe><br />
-      48 位 10,022,253 再生<br />
+      <b>48 位 10,022,253 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31685272" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31685272">DECO*27 - ヒバナ feat. 初音ミク</a></iframe><br />
-      49 位 9,934,228 再生<br />
+      <b>49 位 9,934,228 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm7552074" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm7552074">【マリオ64実況】　奴が来る　六【幕末志士】</a></iframe><br />
-      50 位 9,918,960 再生<br />
+      <b>50 位 9,918,960 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33624822" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33624822">ベノム / flower</a></iframe><br />
-      51 位 9,766,850 再生<br />
+      <b>51 位 9,766,850 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1175788" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1175788">本格的 ガチムチパンツレスリング</a></iframe><br />
-      52 位 9,746,731 再生<br />
+      <b>52 位 9,746,731 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm20244918" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm20244918">【鏡音リン】　ロストワンの号哭　【オリジナルPV付】</a></iframe><br />
-      53 位 9,729,482 再生<br />
+      <b>53 位 9,729,482 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm17024766" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm17024766">MV　『ゴーゴー幽霊船』</a></iframe><br />
-      54 位 9,618,042 再生<br />
+      <b>54 位 9,618,042 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm23538930" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm23538930">神のまにまに 歌ってみた【りぶ×伊東歌詞太郎】</a></iframe><br />
-      55 位 9,455,073 再生<br />
+      <b>55 位 9,455,073 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm36735375" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm36735375">土方の拳OP「岡山を取り戻せ!!」</a></iframe><br />
-      56 位 9,330,514 再生<br />
+      <b>56 位 9,330,514 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm38833751" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm38833751">フォニイ - kafu [オリジナル]</a></iframe><br />
-      57 位 9,291,076 再生<br />
+      <b>57 位 9,291,076 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm25103020" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm25103020">ECHO　歌った　【あらき】</a></iframe><br />
-      58 位 9,099,274 再生<br />
+      <b>58 位 9,099,274 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm42070239" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm42070239">YOASOBI「アイドル」Official Music Video</a></iframe><br />
-      59 位 8,981,935 再生<br />
+      <b>59 位 8,981,935 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm30177801" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm30177801">ダンスロボットダンス / 初音ミク</a></iframe><br />
-      60 位 8,936,701 再生<br />
+      <b>60 位 8,936,701 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm15751190" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm15751190">【初音ミク】カゲロウデイズ【オリジナルPV】</a></iframe><br />
-      61 位 8,930,836 再生<br />
+      <b>61 位 8,930,836 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm13386216" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm13386216">【オリジナル曲PV】 パンダヒーロー 【GUMI】</a></iframe><br />
-      62 位 8,880,122 再生<br />
+      <b>62 位 8,880,122 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6091554" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6091554">東方紅魔郷Ultraモード　2周目突入　Stage1～4</a></iframe><br />
-      63 位 8,856,792 再生<br />
+      <b>63 位 8,856,792 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm39257413" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm39257413">きゅうくらりん / いよわ feat.可不</a></iframe><br />
-      64 位 8,806,082 再生<br />
+      <b>64 位 8,806,082 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm5054636" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm5054636">チルノのパーフェクトさんすう教室(高画質・高音質版)H264</a></iframe><br />
-      65 位 8,797,509 再生<br />
+      <b>65 位 8,797,509 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm28576299" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm28576299">エイリアンエイリアン / 初音ミク</a></iframe><br />
-      66 位 8,770,398 再生<br />
+      <b>66 位 8,770,398 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29385061" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29385061">【MV】Secret Answer/XYZ</a></iframe><br />
-      67 位 8,713,098 再生<br />
+      <b>67 位 8,713,098 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1890440" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1890440">ハイポーション作ってみた。</a></iframe><br />
-      68 位 8,616,285 再生<br />
+      <b>68 位 8,616,285 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm24643818" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm24643818">【VOCALOID 原創】ECHO【Gumi English】</a></iframe><br />
-      69 位 8,613,093 再生<br />
+      <b>69 位 8,613,093 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm3645817" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm3645817">初音ミクがオリジナルを歌ってくれたよ「ブラック★ロックシューター」</a></iframe><br />
-      70 位 8,599,175 再生<br />
+      <b>70 位 8,599,175 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33303514" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33303514">【えっちなAV】結月ゆかりおさんぽデート回【釣り動画1080p】</a></iframe><br />
-      71 位 8,588,321 再生<br />
+      <b>71 位 8,588,321 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm83" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm83">【ｺﾞﾑ】　ロックマン2　おっくせんまん！（Version ｺﾞﾑ）</a></iframe><br />
-      72 位 8,548,022 再生<br />
+      <b>72 位 8,548,022 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2069100" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2069100">θ波潜在能力開発（ヒーリング系作業用BGM)</a></iframe><br />
-      73 位 8,461,805 再生<br />
+      <b>73 位 8,461,805 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29822304" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29822304">シャルル／flower</a></iframe><br />
-      74 位 8,449,480 再生<br />
+      <b>74 位 8,449,480 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/nm6049209" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/nm6049209">【巡音ルカ】ダブルラリアット【オリジナル】</a></iframe><br />
-      75 位 8,409,586 再生<br />
+      <b>75 位 8,409,586 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm39334235" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm39334235">神っぽいな / 初音ミク</a></iframe><br />
-      76 位 8,391,318 再生<br />
+      <b>76 位 8,391,318 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33940434" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33940434">【悲報】ニコニコ動画(く)こける</a></iframe><br />
-      77 位 8,243,154 再生<br />
+      <b>77 位 8,243,154 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31533883" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31533883">『テオ』 / 初音ミク - Omoi</a></iframe><br />
-      78 位 8,229,224 再生<br />
+      <b>78 位 8,229,224 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm37287661" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm37287661">【GUMI】KING【Kanaria】</a></iframe><br />
-      79 位 8,078,698 再生<br />
+      <b>79 位 8,078,698 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm34470195" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm34470195">DECO*27 - 乙女解剖 feat. 初音ミク</a></iframe><br />
-      80 位 8,064,513 再生<br />
+      <b>80 位 8,064,513 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm18623327" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm18623327">【GUMI・鏡音リン】 いーあるふぁんくらぶ 【オリジナルPV】</a></iframe><br />
-      81 位 8,059,506 再生<br />
+      <b>81 位 8,059,506 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32086575" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32086575">君の神様になりたい。 歌ってみたのはメガテラ・ゼロ</a></iframe><br />
-      82 位 8,048,766 再生<br />
+      <b>82 位 8,048,766 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33150993" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33150993">ヨルシカ - ただ君に晴れ (MUSIC VIDEO)</a></iframe><br />
-      83 位 7,943,518 再生<br />
+      <b>83 位 7,943,518 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/so15013657" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/so15013657">うたの☆プリンスさまっ♪ マジLOVE1000％　メインテーマ／マジLOVE1000％（Op.1バージョン）</a></iframe><br />
-      84 位 7,877,348 再生<br />
+      <b>84 位 7,877,348 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32556322" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32556322">命に嫌われている。＠歌ってみた【まふまふ】</a></iframe><br />
-      85 位 7,783,439 再生<br />
+      <b>85 位 7,783,439 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm37276165" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm37276165">マイリスト数、激減してませんか？</a></iframe><br />
-      86 位 7,761,586 再生<br />
+      <b>86 位 7,761,586 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm25337528" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm25337528">【ウォルピス社】夜明けと蛍を歌ってみました【提供】</a></iframe><br />
-      87 位 7,746,583 再生<br />
+      <b>87 位 7,746,583 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11126185" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11126185">怒ってた猫が急に話しかけて来たけど、ネコ語だからわからない</a></iframe><br />
-      88 位 7,725,212 再生<br />
+      <b>88 位 7,725,212 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm26809264" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm26809264">プライド革命 ／ CHiCO with HoneyWorks</a></iframe><br />
-      89 位 7,650,183 再生<br />
+      <b>89 位 7,650,183 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm12825985" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm12825985">ハッピーシンセサイザ / 巡音ルカ GUMI</a></iframe><br />
-      90 位 7,603,653 再生<br />
+      <b>90 位 7,603,653 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm37223238" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm37223238">【えっちなミステリ】変態ガリレオゆかり学【結月ゆかり実況プレイ】</a></iframe><br />
-      91 位 7,591,087 再生<br />
+      <b>91 位 7,591,087 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm18406343" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm18406343">【IA】チルドレンレコード【オリジナルPV】</a></iframe><br />
-      92 位 7,570,682 再生<br />
+      <b>92 位 7,570,682 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm19011429" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm19011429">最強の匠は誰か！？絶望的センス4人衆がMinecraftをカオス実況！</a></iframe><br />
-      93 位 7,492,594 再生<br />
+      <b>93 位 7,492,594 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27594954" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27594954">[A]ddiction / GigaReol×EVO+</a></iframe><br />
-      94 位 7,410,655 再生<br />
+      <b>94 位 7,410,655 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27007441" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27007441">幕末志士達のマリオカート６４実況プレイ</a></iframe><br />
-      95 位 7,397,288 再生<br />
+      <b>95 位 7,397,288 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm36053074" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm36053074">春嵐 / 初音ミク</a></iframe><br />
-      96 位 7,388,642 再生<br />
+      <b>96 位 7,388,642 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm39608927" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm39608927">ロウワー / Flower</a></iframe><br />
-      97 位 7,369,817 再生<br />
+      <b>97 位 7,369,817 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm5457137" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm5457137">【マリオ64実況】　奴が来る　壱【幕末志士】</a></iframe><br />
-      98 位 7,334,265 再生<br />
+      <b>98 位 7,334,265 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm17891898" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm17891898">【作業用BGM】視聴者に選ばれた神曲アニソン☆100曲メドレー【歌詞付き】</a></iframe><br />
-      99 位 7,328,871 再生<br />
+      <b>99 位 7,328,871 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2959233" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2959233">ニコニコ動画流星群</a></iframe><br />
-      100 位 7,314,327 再生<br />
+      <b>100 位 7,314,327 再生</b><br />
       <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6979644" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6979644">【青鬼】絶叫に定評のある友人に無理やり実況させた【実況】part1</a></iframe><br />
     </p>

--- a/data/20240525.html
+++ b/data/20240525.html
@@ -16,304 +16,304 @@
     </ui>
     <p>
       <b>1 位 30,598,274 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm8628149" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm8628149" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm8628149">【東方】Bad Apple!!　ＰＶ【影絵】</a></iframe><br />
       <b>2 位 22,724,730 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2057168" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm2057168" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2057168">M.C.ドナルドはダンスに夢中なのか？最終鬼畜道化師ドナルド・Ｍ</a></iframe><br />
       <b>3 位 21,956,120 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm9" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm9" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm9">新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師</a></iframe><br />
       <b>4 位 20,589,057 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm35919998" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm35919998" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm35919998">【おにべろす】出会いから今までまとめ 百鬼あやめ(鬼)と戌亥とこ（ベロス）</a></iframe><br />
       <b>5 位 17,547,000 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm22954889" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm22954889" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm22954889">幕末志士達のスマブラ６４実況プレイ</a></iframe><br />
       <b>6 位 17,497,458 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm15630734" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm15630734" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm15630734">『初音ミク』千本桜『オリジナル曲PV』</a></iframe><br />
       <b>7 位 17,297,205 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm25932228" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm25932228" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm25932228">【ウォルピス社】アスノヨゾラ哨戒班を歌ってみました【提供】</a></iframe><br />
       <b>8 位 16,901,235 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1097445" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm1097445" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1097445">【初音ミク】みくみくにしてあげる♪【してやんよ】</a></iframe><br />
       <b>9 位 16,276,932 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1715919" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm1715919" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1715919">初音ミク　が　オリジナル曲を歌ってくれたよ「メルト」</a></iframe><br />
       <b>10 位 15,903,319 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm10780722" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm10780722" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm10780722">おちゃめ機能　歌った</a></iframe><br />
       <b>11 位 15,687,195 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm20886696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm20886696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm20886696">ブリキノダンス　うたった【SymaG】</a></iframe><br />
       <b>12 位 15,116,840 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm10759623" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm10759623" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm10759623">初音ミク・巡音ルカ　オリジナル曲　「ワールズエンド・ダンスホール」</a></iframe><br />
       <b>13 位 14,871,347 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/so30413239" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/so30413239" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/so30413239">けものフレンズ　1話「さばんなちほー」</a></iframe><br />
       <b>14 位 14,717,789 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11809611" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm11809611" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11809611">【オリジナル曲PV】マトリョシカ【初音ミク・GUMI】</a></iframe><br />
       <b>15 位 12,824,335 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29885262" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm29885262" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29885262">シャルル　歌ってみたのはメガテラ・ゼロ</a></iframe><br />
       <b>16 位 12,731,279 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11398357" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm11398357" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11398357">DECO*27 - モザイクロール feat. GUMI</a></iframe><br />
       <b>17 位 12,516,504 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31791630" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm31791630" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31791630">wowaka『アンノウン・マザーグース』feat. 初音ミク</a></iframe><br />
       <b>18 位 12,412,768 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm23225630" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm23225630" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm23225630">米津玄師 MV「アイネクライネ」</a></iframe><br />
       <b>19 位 12,244,684 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm9714351" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm9714351" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm9714351">初音ミク　オリジナル曲　「ローリンガール」</a></iframe><br />
       <b>20 位 12,130,390 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm24276234" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm24276234" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm24276234">【IA】アスノヨゾラ哨戒班【オリジナル】</a></iframe><br />
       <b>21 位 12,069,050 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm500873" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm500873" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm500873">組曲『ニコニコ動画』 </a></iframe><br />
       <b>22 位 12,052,862 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32103696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm32103696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32103696">ドラマツルギー 歌ってみた【りぶ】</a></iframe><br />
       <b>23 位 12,044,281 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm35979548" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm35979548" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm35979548">YOASOBI「夜に駆ける」 Official Music Video</a></iframe><br />
       <b>24 位 11,917,594 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27965309" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm27965309" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27965309">DECO*27 - ゴーストルール feat. 初音ミク</a></iframe><br />
       <b>25 位 11,830,687 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6188097" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm6188097" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6188097">【マリオ64実況】　奴が来る　伍【幕末志士】</a></iframe><br />
       <b>26 位 11,800,456 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm15971140" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm15971140" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm15971140">エンヴィキャットウォーク 歌ってみた【りぶ】</a></iframe><br />
       <b>27 位 11,748,254 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/so23335421" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/so23335421" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/so23335421">ご注文はうさぎですか？　第1羽「ひと目で、尋常でないもふもふだと見抜いたよ」</a></iframe><br />
       <b>28 位 11,500,649 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31606995" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm31606995" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31606995">ハチ MV「砂の惑星 feat.初音ミク」</a></iframe><br />
       <b>29 位 11,484,143 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm9354085" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm9354085" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm9354085">自演乙</a></iframe><br />
       <b>30 位 11,458,541 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm17520775" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm17520775" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm17520775">【IA】六兆年と一夜物語【オリジナル曲・PV付】</a></iframe><br />
       <b>31 位 11,413,492 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2049295" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm2049295" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2049295">【 Silver Forest × U.N.オーエンは彼女なのか？ 】 −sweet little sister−</a></iframe><br />
       <b>32 位 11,228,694 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29854242" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm29854242" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29854242">シャルル／バルーン</a></iframe><br />
       <b>33 位 11,152,069 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2937784" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm2937784" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2937784">初音ミクオリジナル曲　「初音ミクの消失（LONG VERSION）」</a></iframe><br />
       <b>34 位 10,942,373 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm14583646" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm14583646" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm14583646">天ノ弱／164 feat.GUMI</a></iframe><br />
       <b>35 位 10,824,481 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm23328696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm23328696" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm23328696">【ニコニコラボ】Blessing【SINGERS ver.A】</a></iframe><br />
       <b>36 位 10,724,808 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm22138447" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm22138447" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm22138447">GUMI MV「ドーナツホール」</a></iframe><br />
       <b>37 位 10,702,232 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm26515642" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm26515642" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm26515642">【血界戦線ED】シュガーソングとビターステップを歌ってみた　まるぐり</a></iframe><br />
       <b>38 位 10,693,186 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm22960446" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm22960446" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm22960446">【初音ミク】 ウミユリ海底譚 【オリジナル曲】</a></iframe><br />
       <b>39 位 10,633,598 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm19133907" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm19133907" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm19133907">【初音ミク＆GUMI】脳漿炸裂ガール【オリジナル】</a></iframe><br />
       <b>40 位 10,623,571 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm30171731" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm30171731" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm30171731">【FantasticYouth】 DAYBREAK FRONTLINE 歌ってみた 【LowFat×おん湯(♨︎)】</a></iframe><br />
       <b>41 位 10,542,768 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm3504435" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm3504435" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm3504435">初音ミク　が　オリジナル曲を歌ってくれたよ「ワールドイズマイン」</a></iframe><br />
       <b>42 位 10,446,801 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm8082467" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm8082467" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm8082467">初音ミク　オリジナル曲　「裏表ラバーズ」</a></iframe><br />
       <b>43 位 10,270,471 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6666016" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm6666016" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6666016">「ロミオとシンデレラ」　オリジナル曲　vo.初音ミク</a></iframe><br />
       <b>44 位 10,220,385 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm8089993" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm8089993" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm8089993">【鏡音リン】炉心融解【オリジナル】</a></iframe><br />
       <b>45 位 10,217,861 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11729204" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm11729204" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11729204">【うるおぼえで歌ってみた】only my railgun【ぐるたみん】</a></iframe><br />
       <b>46 位 10,188,109 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32798041" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm32798041" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32798041">ロキ／鏡音リン・みきとP</a></iframe><br />
       <b>47 位 10,065,837 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27831783" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm27831783" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27831783">【ウォルピス社】時ノ雨、最終戦争を歌ってみました【提供】</a></iframe><br />
       <b>48 位 10,022,253 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31685272" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm31685272" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31685272">DECO*27 - ヒバナ feat. 初音ミク</a></iframe><br />
       <b>49 位 9,934,228 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm7552074" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm7552074" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm7552074">【マリオ64実況】　奴が来る　六【幕末志士】</a></iframe><br />
       <b>50 位 9,918,960 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33624822" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm33624822" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33624822">ベノム / flower</a></iframe><br />
       <b>51 位 9,766,850 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1175788" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm1175788" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1175788">本格的 ガチムチパンツレスリング</a></iframe><br />
       <b>52 位 9,746,731 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm20244918" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm20244918" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm20244918">【鏡音リン】　ロストワンの号哭　【オリジナルPV付】</a></iframe><br />
       <b>53 位 9,729,482 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm17024766" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm17024766" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm17024766">MV　『ゴーゴー幽霊船』</a></iframe><br />
       <b>54 位 9,618,042 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm23538930" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm23538930" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm23538930">神のまにまに 歌ってみた【りぶ×伊東歌詞太郎】</a></iframe><br />
       <b>55 位 9,455,073 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm36735375" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm36735375" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm36735375">土方の拳OP「岡山を取り戻せ!!」</a></iframe><br />
       <b>56 位 9,330,514 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm38833751" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm38833751" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm38833751">フォニイ - kafu [オリジナル]</a></iframe><br />
       <b>57 位 9,291,076 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm25103020" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm25103020" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm25103020">ECHO　歌った　【あらき】</a></iframe><br />
       <b>58 位 9,099,274 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm42070239" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm42070239" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm42070239">YOASOBI「アイドル」Official Music Video</a></iframe><br />
       <b>59 位 8,981,935 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm30177801" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm30177801" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm30177801">ダンスロボットダンス / 初音ミク</a></iframe><br />
       <b>60 位 8,936,701 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm15751190" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm15751190" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm15751190">【初音ミク】カゲロウデイズ【オリジナルPV】</a></iframe><br />
       <b>61 位 8,930,836 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm13386216" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm13386216" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm13386216">【オリジナル曲PV】 パンダヒーロー 【GUMI】</a></iframe><br />
       <b>62 位 8,880,122 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6091554" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm6091554" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6091554">東方紅魔郷Ultraモード　2周目突入　Stage1～4</a></iframe><br />
       <b>63 位 8,856,792 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm39257413" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm39257413" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm39257413">きゅうくらりん / いよわ feat.可不</a></iframe><br />
       <b>64 位 8,806,082 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm5054636" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm5054636" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm5054636">チルノのパーフェクトさんすう教室(高画質・高音質版)H264</a></iframe><br />
       <b>65 位 8,797,509 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm28576299" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm28576299" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm28576299">エイリアンエイリアン / 初音ミク</a></iframe><br />
       <b>66 位 8,770,398 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29385061" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm29385061" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29385061">【MV】Secret Answer/XYZ</a></iframe><br />
       <b>67 位 8,713,098 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm1890440" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm1890440" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm1890440">ハイポーション作ってみた。</a></iframe><br />
       <b>68 位 8,616,285 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm24643818" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm24643818" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm24643818">【VOCALOID 原創】ECHO【Gumi English】</a></iframe><br />
       <b>69 位 8,613,093 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm3645817" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm3645817" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm3645817">初音ミクがオリジナルを歌ってくれたよ「ブラック★ロックシューター」</a></iframe><br />
       <b>70 位 8,599,175 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33303514" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm33303514" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33303514">【えっちなAV】結月ゆかりおさんぽデート回【釣り動画1080p】</a></iframe><br />
       <b>71 位 8,588,321 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm83" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm83" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm83">【ｺﾞﾑ】　ロックマン2　おっくせんまん！（Version ｺﾞﾑ）</a></iframe><br />
       <b>72 位 8,548,022 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2069100" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm2069100" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2069100">θ波潜在能力開発（ヒーリング系作業用BGM)</a></iframe><br />
       <b>73 位 8,461,805 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm29822304" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm29822304" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm29822304">シャルル／flower</a></iframe><br />
       <b>74 位 8,449,480 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/nm6049209" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/nm6049209" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/nm6049209">【巡音ルカ】ダブルラリアット【オリジナル】</a></iframe><br />
       <b>75 位 8,409,586 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm39334235" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm39334235" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm39334235">神っぽいな / 初音ミク</a></iframe><br />
       <b>76 位 8,391,318 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33940434" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm33940434" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33940434">【悲報】ニコニコ動画(く)こける</a></iframe><br />
       <b>77 位 8,243,154 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm31533883" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm31533883" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm31533883">『テオ』 / 初音ミク - Omoi</a></iframe><br />
       <b>78 位 8,229,224 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm37287661" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm37287661" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm37287661">【GUMI】KING【Kanaria】</a></iframe><br />
       <b>79 位 8,078,698 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm34470195" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm34470195" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm34470195">DECO*27 - 乙女解剖 feat. 初音ミク</a></iframe><br />
       <b>80 位 8,064,513 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm18623327" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm18623327" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm18623327">【GUMI・鏡音リン】 いーあるふぁんくらぶ 【オリジナルPV】</a></iframe><br />
       <b>81 位 8,059,506 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32086575" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm32086575" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32086575">君の神様になりたい。 歌ってみたのはメガテラ・ゼロ</a></iframe><br />
       <b>82 位 8,048,766 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm33150993" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm33150993" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm33150993">ヨルシカ - ただ君に晴れ (MUSIC VIDEO)</a></iframe><br />
       <b>83 位 7,943,518 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/so15013657" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/so15013657" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/so15013657">うたの☆プリンスさまっ♪ マジLOVE1000％　メインテーマ／マジLOVE1000％（Op.1バージョン）</a></iframe><br />
       <b>84 位 7,877,348 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm32556322" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm32556322" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm32556322">命に嫌われている。＠歌ってみた【まふまふ】</a></iframe><br />
       <b>85 位 7,783,439 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm37276165" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm37276165" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm37276165">マイリスト数、激減してませんか？</a></iframe><br />
       <b>86 位 7,761,586 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm25337528" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm25337528" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm25337528">【ウォルピス社】夜明けと蛍を歌ってみました【提供】</a></iframe><br />
       <b>87 位 7,746,583 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm11126185" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm11126185" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm11126185">怒ってた猫が急に話しかけて来たけど、ネコ語だからわからない</a></iframe><br />
       <b>88 位 7,725,212 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm26809264" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm26809264" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm26809264">プライド革命 ／ CHiCO with HoneyWorks</a></iframe><br />
       <b>89 位 7,650,183 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm12825985" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm12825985" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm12825985">ハッピーシンセサイザ / 巡音ルカ GUMI</a></iframe><br />
       <b>90 位 7,603,653 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm37223238" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm37223238" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm37223238">【えっちなミステリ】変態ガリレオゆかり学【結月ゆかり実況プレイ】</a></iframe><br />
       <b>91 位 7,591,087 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm18406343" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm18406343" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm18406343">【IA】チルドレンレコード【オリジナルPV】</a></iframe><br />
       <b>92 位 7,570,682 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm19011429" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm19011429" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm19011429">最強の匠は誰か！？絶望的センス4人衆がMinecraftをカオス実況！</a></iframe><br />
       <b>93 位 7,492,594 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27594954" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm27594954" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27594954">[A]ddiction / GigaReol×EVO+</a></iframe><br />
       <b>94 位 7,410,655 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm27007441" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm27007441" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm27007441">幕末志士達のマリオカート６４実況プレイ</a></iframe><br />
       <b>95 位 7,397,288 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm36053074" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm36053074" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm36053074">春嵐 / 初音ミク</a></iframe><br />
       <b>96 位 7,388,642 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm39608927" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm39608927" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm39608927">ロウワー / Flower</a></iframe><br />
       <b>97 位 7,369,817 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm5457137" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm5457137" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm5457137">【マリオ64実況】　奴が来る　壱【幕末志士】</a></iframe><br />
       <b>98 位 7,334,265 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm17891898" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm17891898" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm17891898">【作業用BGM】視聴者に選ばれた神曲アニソン☆100曲メドレー【歌詞付き】</a></iframe><br />
       <b>99 位 7,328,871 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm2959233" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm2959233" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm2959233">ニコニコ動画流星群</a></iframe><br />
       <b>100 位 7,314,327 再生</b><br />
-      <iframe width="550" height="120" src="https://ext.nicovideo.jp/thumb/sm6979644" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
+      <iframe width="550" height="140" src="https://ext.nicovideo.jp/thumb/sm6979644" scrolling="no" style="border: solid 1px #ccc" frameborder="0"
       ><a href="https://www.nicovideo.jp/watch/sm6979644">【青鬼】絶叫に定評のある友人に無理やり実況させた【実況】part1</a></iframe><br />
     </p>
   </body>


### PR DESCRIPTION
## WHY・WHAT

PC・スマホで改めて見てみて、微妙な点を改善

- リンクのテンプレ上部の黒帯が強いため順位と再生数が目立たないので、太字にした
- スマホ (iPhoneのSafari) で見るとテンプレが欠けている
  - PCのChromeの開発者ツールでもスマホビューを試せるが、それだと欠けない
  - サムネが全部見えるくらいの高さを見積もって、それに設定した
    - 動画時間が入るほど高くすると、(PC・スマホ両方で) 1画面に入る動画数が減るので、動画時間は入れなかった

スマホ・改善前

![IMG_9781](https://github.com/tomii9273/niconico_ranking/assets/9714141/38d58a3b-149f-4b55-91a6-9b98c579870b)

スマホ・改善後

![IMG_9782](https://github.com/tomii9273/niconico_ranking/assets/9714141/0aa9300c-4132-4151-a500-f752b526141a)


## その他

- スマホでは投稿日時の文字サイズが大きく (再生数等と同じ大きさ) / 小さく (動画タイトルと同じ大きさ) なることがある。動画説明が1行だけ⇔小さい、となっていそう。(特に対処しない。)